### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/KSCSwitcher/KSCSwitcher.version
+++ b/GameData/KSCSwitcher/KSCSwitcher.version
@@ -1,6 +1,6 @@
 {
   "NAME": "KSC Switcher",
-  "URL": "https://github.com/KSP-RO/KSCSwitcher",
+  "URL": "https://github.com/KSP-RO/KSCSwitcher/raw/master/GameData/KSCSwitcher/KSCSwitcher.version",
   "DOWNLOAD": "https://github.com/KSP-RO/KSCSwitcher/releases",
   "GITHUB": {
     "USERNAME": "KSP-RO",


### PR DESCRIPTION
The "URL" property is supposed to point to an online copy of the version file, so KSP-AVC can check for updates.
Now it does.